### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/rust-nostd/Cargo.toml
+++ b/rust-nostd/Cargo.toml
@@ -6,8 +6,8 @@ description = "Ubiquitous General Purpose Tag"
 authors = ["Jean-Louis Fuchs <safe.pen2857@rhizoome.ch>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-homepage = "http://github.com/rhizoome/rhiz_tag"
-repository = "http://github.com/rhizoome/rhiz_tag"
+homepage = "https://github.com/rhizoome/rhiz_tag"
+repository = "https://github.com/rhizoome/rhiz_tag"
 keywords = ["tag", "no-std", "date-and-time", "archival", "note-taking"]
 categories = ["date-and-time", "no-std", "command-line-utilities"] 
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97